### PR TITLE
Fixed syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ftpush: {
     },
     src: 'path/to/source/folder',
     dest: '/path/to/destination/folder',
-    exclusions: ['path/to/source/folder/**/.DS_Store', 'path/to/source/folder/**/Thumbs.db', 'dist/tmp']
+    exclusions: ['path/to/source/folder/**/.DS_Store', 'path/to/source/folder/**/Thumbs.db', 'dist/tmp'],
     keep: ['/important/images/at/server/*.jpg']
   }
 }


### PR DESCRIPTION
Thanks again for this great plugin! I was about to fork grunt-ftp-deploy and try to write some PRs until finding this.
## Syntax Error

I found this syntax error using mdlint: https://github.com/ChrisWren/mdlint. Check it out if you frequently write markdown files with JavaScript code blocks.
## Ideas for development

Would you be interested in the idea of streamlining the README to ignore some of the context about the creation of this plugin, instead mentioning it later in the README? Basically this would entail moving everything before Getting Started below the usage information.

From my usage, I will always be using the --simple flag as jsftp is unstable. I had similar instability issues with grunt-ftp-deploy which prevented me from using it. What do you think about making --simple the default?

Thanks again for your great work.
