### PR TITLE
Adds capability to specify cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ ftpush: {
     exclusions: ['path/to/source/folder/**/.DS_Store', 'path/to/source/folder/**/Thumbs.db', 'dist/tmp'],
     keep: ['/important/images/at/server/*.jpg'],
     simple: false,
-    useList: false
+    useList: false,
+    cachePath: 'path/to/cache/folder/any_name.json'
   }
 }
 ```
@@ -72,6 +73,7 @@ The possible parameters of the configuration are:
 - **keep** - an array of paths that should be kept on the server even when they are not presented locally. The definitions should be relative to `dest`.
 - **simple** - if set to `true`, task will upload modified files and quit, it will NOT remove redundant files and directories at the server side.
 - **useList** - if set to `true`, FTP client will be enforced to use LIST command instead of STAT (that is not supported by some of servers)
+- **cachePath** - optional local path of file that will store all hashes of already uploaded files. If no path is specified, will use default path '.grunt/ftpush/{taskName}.json
 
 ## Options
 

--- a/tasks/ftpush.coffee
+++ b/tasks/ftpush.coffee
@@ -24,6 +24,7 @@ module.exports = (grunt) ->
     credentials = if @data.auth.authKey then auth(@data.auth.authKey) else auth(@data.auth.host)
     exclusions  = @data.exclusions || []
     keep        = @data.keep || []
+    cachePath = @data.cachePath || Path.join(".grunt", "ftpush", "#{@target}.json")   
     options     =
       useList: !!@data.useList
       remove:  !(grunt.option('simple') || @data.simple)
@@ -33,7 +34,7 @@ module.exports = (grunt) ->
     sync = new Synchronizer(
       localRoot,
       remoteRoot,
-      Path.join(".grunt", "ftpush", "#{@target}.json"),
+      cachePath,
       Object.merge(@data.auth, credentials),
       exclusions,
       keep,


### PR DESCRIPTION
# Why I Created This?
I'm working at one project that needs to deploy same files to multiple environments. 
When I upload to first environment, grunt-ftpush saves in memory file all hashes of files. So when I try to upload to second environment, is like all these files are already uploaded, and nothing is uploaded =\.

So I was deleting .grunt folder. By the way, I developed this solution. My Gruntfile.js has one environment variable, and I concat that variable to cachePath. That way I have separated cache files for each environment.